### PR TITLE
Adding functionality for the pre-ingestion of Corp Identity Device map

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,4 +1,3 @@
-// Test
 package main
 
 import (

--- a/main.go
+++ b/main.go
@@ -18,53 +18,64 @@ const (
 	appleIdentifier          = byte(0x004C) // 0x004C is the company identifier for Apple.
 	findMyNetworkBroadcastID = byte(0x12)   // 0x12 is the broadcast ID for the FindMy network.
 	adManSpecData            = byte(0xFF)   // 0xFF is the AD type for manufacturer specific data.
-	scannerRunTime           = 10           // The number of seconds to run the scanner.
 	companyIdentlocation     = "company_identifiers.yaml"
 	scanWait                 = time.Duration(1 * time.Second)
+	scanTime                 = time.Duration(5 * time.Second)
 )
 
-type manufacturerData map[uint16][]byte
+// bluetooth devices manufacturer data.
+type manData map[uint16][]byte
 
 type devContent struct {
 	manufacturerData map[uint16][]byte
-	localName        string
-	companyIdent     uint16
+	localName        devName
+	companyIdent     devValue
 }
 
-type trackingDevices map[uint16]map[uint16]devContent
+// map to hold the devices found.
+type bleDevs map[uint16]map[uint16]devContent
+
+type devValue uint16
+type devName string
+
+// map to hold the company identifiers.
+type CorpIdentMap map[devValue]devName
 
 var (
 	adapter = bluetooth.DefaultAdapter
-	devices = make(trackingDevices)
+	devices = make(bleDevs)
+	cmap    = make(CorpIdentMap)
 )
 
 func main() {
+	// Ingest the company identifiers.
+	cmap = ingestCorpDevices(companyIdentlocation)
 	// Enable BLE interface.
+	must("enable BLE stack", adapter.Enable())
 	ptab := table.NewWriter()
 	ptab.SetOutputMirror(os.Stdout)
 	ptab.AppendHeader(table.Row{"Device ID", "Name", "Company", "FindMy"})
-	must("enable BLE stack", adapter.Enable())
 	for {
 		// Start scanning.
 		fmt.Println("Scanning for nearby Bluetooth devices...")
 		t := time.Now()
 		err := adapter.Scan(func(adapter *bluetooth.Adapter, device bluetooth.ScanResult) {
-			if time.Now().After(t.Add(scannerRunTime * time.Second)) {
+			if time.Now().After(t.Add(scanTime)) {
 				fmt.Println("Scan time exceeded")
 				adapter.StopScan() // Stop scanning after 10 seconds.
 			}
 			devices[device.Address.Get16Bit()] = map[uint16]devContent{
 				device.Address.Get16Bit(): {
 					manufacturerData: device.ManufacturerData(),
-					localName:        device.LocalName(),
-					companyIdent:     getCompanyIdent(device.ManufacturerData()),
+					localName:        devName(device.LocalName()),
+					companyIdent:     devValue(getCompanyIdent(device.ManufacturerData())),
 				}}
 		})
 		must("start scan", err)
 		// Print the devices found.
 		fmt.Println("Devices found:")
 		for k, v := range devices {
-			companyName := resolveCompanyIdent(v[k].companyIdent)
+			companyName := resolveCompanyIdent(&cmap, v[k].companyIdent)
 			localName := v[k].localName
 			findMyDevice := isFindMyDevice(v[k].manufacturerData)
 			ptab.AppendRow(table.Row{
@@ -82,7 +93,7 @@ func main() {
 		// Reset the rows in the table.
 		ptab.ResetRows()
 		// clear the devices map.
-		devices = make(trackingDevices)
+		devices = make(bleDevs)
 		// Wait x seconds before scanning again.
 		time.Sleep(scanWait)
 	}
@@ -118,7 +129,7 @@ func clearScreen() {
 	cmd.Run()
 }
 
-func getCompanyIdent(md manufacturerData) uint16 {
+func getCompanyIdent(md manData) uint16 {
 	if len(md) > 0 {
 		for manId := range md {
 			return manId
@@ -127,23 +138,33 @@ func getCompanyIdent(md manufacturerData) uint16 {
 	return 0
 }
 
-func resolveCompanyIdent(companyIdent uint16) string {
-	// define a map to hold the company identifiers.
-	type CompanyIdentifier struct {
-		Value uint16 `yaml:"value"`
-		Name  string `yaml:"name"`
+// resolveCompanyIdent returns the name of the company from the ingested company identifiers.
+func resolveCompanyIdent(c *CorpIdentMap, t devValue) devName {
+	if val, ok := (*c)[t]; ok {
+		return val
 	}
+	return "Unknown"
+}
+
+// ingestCorpDevices reads the company identifiers from a YAML file and returns a map of the company identifiers.
+func ingestCorpDevices(loc string) CorpIdentMap {
+	cmap = make(CorpIdentMap)
+	// define a map to hold individual company identifiers.
+	type CompanyIdentifier struct {
+		Value devValue `yaml:"value"`
+		Name  devName  `yaml:"name"`
+	}
+	// define a struct to the top level company identifiers list.
 	type CompanyIdentifiers struct {
 		CompanyIdentifiers []CompanyIdentifier `yaml:"company_identifiers"`
 	}
 
 	// Open the file and read the contents.
-	file, err := os.Open(companyIdentlocation)
+	file, err := os.Open(loc)
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer file.Close()
-
 	// Create a new YAML decoder.
 	d := yaml.NewDecoder(file)
 	// Create a new struct to hold the unmarshaled data.
@@ -156,12 +177,7 @@ func resolveCompanyIdent(companyIdent uint16) string {
 	}
 	// Loop through the company identifiers and return the name of the company.
 	for _, v := range c.CompanyIdentifiers {
-		// test line to print the company identifiers against the yaml file.
-		if v.Value == companyIdent {
-			return v.Name
-		}
+		cmap[v.Value] = v.Name
 	}
-
-	return "unkown"
-
+	return cmap
 }

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func main() {
 		fmt.Println("Devices found:")
 		for k, v := range devices {
 			companyName := resolveCompanyIdent(v[k].companyIdent)
-			localName := vcl[k].localName
+			localName := v[k].localName
 			findMyDevice := isFindMyDevice(v[k].manufacturerData)
 			ptab.AppendRow(table.Row{
 				fmt.Sprintf("%x", k),

--- a/main.go
+++ b/main.go
@@ -1,3 +1,4 @@
+// Test
 package main
 
 import (
@@ -20,6 +21,7 @@ const (
 	adManSpecData            = byte(0xFF)   // 0xFF is the AD type for manufacturer specific data.
 	scannerRunTime           = 10           // The number of seconds to run the scanner.
 	companyIdentlocation     = "company_identifiers.yaml"
+	scanWait                 = time.Duration(1 * time.Second)
 )
 
 type manufacturerData map[uint16][]byte
@@ -64,21 +66,26 @@ func main() {
 		fmt.Println("Devices found:")
 		for k, v := range devices {
 			companyName := resolveCompanyIdent(v[k].companyIdent)
+			localName := vcl[k].localName
+			findMyDevice := isFindMyDevice(v[k].manufacturerData)
 			ptab.AppendRow(table.Row{
 				fmt.Sprintf("%x", k),
-				v[k].localName,
+				localName,
 				companyName,
-				isFindMyDevice(v[k].manufacturerData),
+				findMyDevice,
 			})
 		}
 		ptab.SetStyle(table.StyleRounded)
-		// clearScreen()
+		// clears the screen.
+		clearScreen()
+		// Render the table.
 		ptab.Render()
-		// Clear the devices map.
+		// Reset the rows in the table.
 		ptab.ResetRows()
+		// clear the devices map.
 		devices = make(trackingDevices)
-		// Wait 5 seconds before scanning again.
-		time.Sleep(5 * time.Second)
+		// Wait x seconds before scanning again.
+		time.Sleep(scanWait)
 	}
 
 }


### PR DESCRIPTION
Objective:
pre-ingest the large YAML list of corporate device names into a hash map.
The previous method was to ingest this yaml file, and parse through the list from top to bottom looking for and returning a corporate UUID match. 

The New method pre-ingests that file into a hashmap, and then obtains the value from that hashmap. This is much more efficient. 