### PR TITLE
Fix shutdown panic risk, non-deterministic company ID, garbled multi-entry rows

### DIFF
--- a/blescan.go
+++ b/blescan.go
@@ -332,5 +332,3 @@ func (s *scanner) getSortedDevices() deviceList {
 	sort.Sort(sorted)
 	return sorted
 }
-
-

--- a/corpIdent.go
+++ b/corpIdent.go
@@ -52,10 +52,25 @@ func loadCompanyIdentifiers(filePath string) CompanyIdentifiers {
 	return identifiers
 }
 
-// extractCompanyID returns the first company ID found in manufacturer data.
+const appleCompanyID uint16 = 0x004C
+
+// extractCompanyID returns a deterministic company ID from manufacturer data:
+// Apple's ID if present (this tool is Apple-device focused), otherwise the
+// lowest ID. Map iteration order is randomized, so picking "the first" key
+// by ranging (the old behavior) flickered between entries on every render
+// for devices broadcasting more than one manufacturer-data entry.
 func extractCompanyID(mfrData ManufacturerData) uint16 {
-	for companyID := range mfrData {
-		return companyID
+	if _, ok := mfrData[appleCompanyID]; ok {
+		return appleCompanyID
 	}
-	return 0
+
+	first := true
+	var lowest uint16
+	for companyID := range mfrData {
+		if first || companyID < lowest {
+			lowest = companyID
+			first = false
+		}
+	}
+	return lowest
 }

--- a/corpIdent_test.go
+++ b/corpIdent_test.go
@@ -1,0 +1,27 @@
+package main
+
+import "testing"
+
+func TestExtractCompanyID_PrefersApple(t *testing.T) {
+	data := ManufacturerData{0x0001: {1}, appleCompanyID: {2}, 0x9999: {3}}
+	for i := 0; i < 20; i++ {
+		if got := extractCompanyID(data); got != appleCompanyID {
+			t.Fatalf("extractCompanyID() = %#x, want %#x (Apple)", got, appleCompanyID)
+		}
+	}
+}
+
+func TestExtractCompanyID_DeterministicWithoutApple(t *testing.T) {
+	data := ManufacturerData{0x0050: {1}, 0x0010: {2}, 0x0030: {3}}
+	for i := 0; i < 20; i++ {
+		if got := extractCompanyID(data); got != 0x0010 {
+			t.Fatalf("extractCompanyID() = %#x, want %#x (lowest)", got, 0x0010)
+		}
+	}
+}
+
+func TestExtractCompanyID_Empty(t *testing.T) {
+	if got := extractCompanyID(ManufacturerData{}); got != 0 {
+		t.Fatalf("extractCompanyID() on empty map = %#x, want 0", got)
+	}
+}

--- a/devicewriter.go
+++ b/devicewriter.go
@@ -15,12 +15,12 @@ var (
 )
 
 type screenWriter struct {
-	wg         *sync.WaitGroup
-	table      table.Writer
-	header     table.Row
-	quit       chan any
-	inputChan  DeviceChannel
-	devices    deviceList
+	wg        *sync.WaitGroup
+	table     table.Writer
+	header    table.Row
+	quit      chan any
+	inputChan DeviceChannel
+	devices   deviceList
 }
 
 func newWriter(wg *sync.WaitGroup, output *os.File, header table.Row, quit chan any, input DeviceChannel) *screenWriter {
@@ -103,14 +103,14 @@ func (w *screenWriter) render() {
 
 		batteryLevel := dev.getBatteryLevel()
 
-		var hexBytes []string
 		for _, payload := range dev.ManufacturerData() {
-			if len(payload) > 0 {
-				for _, b := range payload {
-					hexBytes = append(hexBytes, fmt.Sprintf("%X", b))
-				}
-			} else {
+			if len(payload) == 0 {
 				w.table.AppendRow(table.Row{"None"})
+				continue
+			}
+			var hexBytes []string
+			for _, b := range payload {
+				hexBytes = append(hexBytes, fmt.Sprintf("%X", b))
 			}
 			w.table.AppendRow(table.Row{
 				dev.scanResult.Address.String(),

--- a/main.go
+++ b/main.go
@@ -4,7 +4,9 @@ import (
 	"flag"
 	"log"
 	"os"
+	"os/signal"
 	"sync"
+	"syscall"
 )
 
 var (
@@ -23,16 +25,30 @@ func main() {
 	deviceChan := make(DeviceChannel)
 	wg := sync.WaitGroup{}
 
-	wg.Add(2)
+	scannerQuit := make(chan any)
+	writerQuit := make(chan any)
+
+	// 3 goroutines call wg.Done(): scanner.scan(), scanner.startScan()
+	// (both share scannerQuit), and writer.execute() (writerQuit).
+	wg.Add(3)
 
 	go func() {
-		err := startBleScanner(&wg, deviceChan, make(chan any))
+		err := startBleScanner(&wg, deviceChan, scannerQuit)
 		mustSucceed("start Bluetooth scanner", err)
 	}()
 
 	go func() {
-		err := startWriter(&wg, make(chan any), os.Stdout, header, deviceChan)
+		err := startWriter(&wg, writerQuit, os.Stdout, header, deviceChan)
 		mustSucceed("start display writer", err)
+	}()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigChan
+		log.Printf("Shutting down...")
+		close(scannerQuit)
+		close(writerQuit)
 	}()
 
 	wg.Wait()


### PR DESCRIPTION
Fixes #5, #6, #7 — findings from a full architecture + security review pass.

## What's fixed
- **#5**: Shutdown was dead code (no signal handling existed at all) and would have panicked with a negative WaitGroup counter if ever wired up (`wg.Add(2)` but 3 goroutines call `Done()`). Now wires real Ctrl-C/SIGTERM handling with the correct WaitGroup budget.
- **#6**: Company-name display flickered non-deterministically for devices with multiple manufacturer-data entries (relied on Go's randomized map iteration order). Now deterministically prefers Apple's company ID, falling back to the lowest ID.
- **#7**: The render loop accumulated hex bytes across manufacturer-data entries and produced an extra malformed row on empty entries. Now resets per-entry and skips the malformed fallthrough.
- gofmt cleanup (pre-existing misalignment in blescan.go/devicewriter.go).

## Verification
- `go build ./...`, `go vet ./...`, `gofmt -l .` all clean.
- Added 3 unit tests for the company-ID determinism fix (`go test ./...` passes).
- Security review pass found no vulnerabilities (byte-parsing in airtag_protocol.go was already properly bounds-checked against malformed BLE advertisement data).
- Also filed #8 (dependency 7 minor versions behind) as a separate, lower-priority item — not touched here since it needs hardware retest.

Not touched: the `sync.Map` usage in blescan.go is single-goroutine-accessed overkill (not a bug, just unneeded complexity) — left as a separate cleanup opportunity rather than bundling into this fix.