### PR TITLE
Fix data race on scanner.scanCount

### DIFF
--- a/blescan.go
+++ b/blescan.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"tinygo.org/x/bluetooth"
@@ -96,7 +97,7 @@ type scanner struct {
 	startTime   time.Time          // When scanning started.
 	quit        chan any           // Channel to signal shutdown.
 	outputChan  DeviceChannel      // Channel to send device lists to writer.
-	scanCount   int                // Number of scan cycles completed.
+	scanCount   atomic.Int64       // Number of scan cycles completed. Written by scan(), read by startScan() - must stay atomic.
 }
 
 // device wraps a BLE scan result with tracking metadata.
@@ -198,7 +199,7 @@ func (d device) CompanyID() uint16 {
 
 // scan continuously discovers BLE devices and sends them to discoveredDevices channel.
 func (s *scanner) scan(discoveredDevices chan bluetooth.ScanResult, displayRefresh chan any) {
-	s.scanCount = 0
+	s.scanCount.Store(0)
 	for {
 		scanDelayTimer := time.NewTimer(scanRate)
 		select {
@@ -211,7 +212,7 @@ func (s *scanner) scan(discoveredDevices chan bluetooth.ScanResult, displayRefre
 			err := s.adapter.Scan(func(adapter *bluetooth.Adapter, result bluetooth.ScanResult) {
 				select {
 				case <-scanDurationTimer.C:
-					s.scanCount++
+					s.scanCount.Add(1)
 					displayRefresh <- nil
 					adapter.StopScan()
 					return
@@ -280,7 +281,7 @@ func (s *scanner) startScan() {
 
 		case <-displayRefresh:
 			snapshot := s.getSortedDevices()
-			snapshot.scanCount = s.scanCount
+			snapshot.scanCount = int(s.scanCount.Load())
 			s.outputChan <- snapshot
 
 		case <-cleanupTicker.C:

--- a/blescan_test.go
+++ b/blescan_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestScannerScanCount_ConcurrentAccess reproduces the write/read pattern from
+// scan() (writer) and startScan() (reader): scanCount is written in one
+// goroutine and read in another while scanning is in progress. Before the
+// atomic.Int64 fix, `go test -race` flagged this as a data race
+// (see beads-yly / issue #11). This test fails under -race on a regression.
+func TestScannerScanCount_ConcurrentAccess(t *testing.T) {
+	s := &scanner{}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		s.scanCount.Store(0)
+		for i := 0; i < 1000; i++ {
+			s.scanCount.Add(1)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			_ = s.scanCount.Load()
+		}
+	}()
+
+	wg.Wait()
+
+	if got := s.scanCount.Load(); got != 1000 {
+		t.Fatalf("scanCount = %d, want 1000", got)
+	}
+}


### PR DESCRIPTION
## Summary
- `scanner.scanCount` was a plain `int` written in `scan()` and read in `startScan()` — two different goroutines, no synchronization. `go test -race` flags it.
- Switched it to `atomic.Int64`; updated the three call sites (`Store`/`Add`/`Load`).
- Currently low-severity (it only feeds a display counter), but fragile as the code evolves — closing it now while it's cheap.

Fixes beads-yly / #11.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — new regression test reproduces the concurrent write/read pattern; confirmed it fails under `-race` without the fix, passes with it.