### PR TITLE
Fix manufacturer-data render: per-entry company label + full-width empty rows

### DIFF
--- a/devicewriter.go
+++ b/devicewriter.go
@@ -55,6 +55,40 @@ func (w *screenWriter) execute() {
 	}
 }
 
+// manufacturerCell is one rendered manufacturer-data entry: the company that
+// owns THIS entry's company ID paired with THIS entry's payload bytes.
+type manufacturerCell struct {
+	company string
+	data    string
+}
+
+// manufacturerCells produces one cell per manufacturer-data entry, pairing each
+// entry's own company ID with its own payload. Two bugs this guards against:
+//   - the company label must come from the entry's map key, not the device-wide
+//     CompanyID() (which is Apple-preferred) — otherwise a non-Apple entry gets
+//     mislabeled "Apple Inc." while showing its own (non-Apple) hex payload.
+//   - an empty payload still yields a full data cell ("(none)"), so the caller
+//     builds a full-width table row instead of a single-column one that would
+//     misalign under the header.
+func manufacturerCells(md map[uint16][]byte, names *CompanyIdentifiers) []manufacturerCell {
+	cells := make([]manufacturerCell, 0, len(md))
+	for companyID, payload := range md {
+		data := "(none)"
+		if len(payload) > 0 {
+			hexBytes := make([]string, 0, len(payload))
+			for _, b := range payload {
+				hexBytes = append(hexBytes, fmt.Sprintf("%X", b))
+			}
+			data = fmt.Sprintf("%v: %v", hexBytes, len(hexBytes))
+		}
+		cells = append(cells, manufacturerCell{
+			company: getCompanyName(names, companyID),
+			data:    data,
+		})
+	}
+	return cells
+}
+
 // render draws the device table to the terminal.
 func (w *screenWriter) render() {
 	termWidth, termHeight, err := getTerminalSize()
@@ -103,19 +137,11 @@ func (w *screenWriter) render() {
 
 		batteryLevel := dev.getBatteryLevel()
 
-		for _, payload := range dev.ManufacturerData() {
-			if len(payload) == 0 {
-				w.table.AppendRow(table.Row{"None"})
-				continue
-			}
-			var hexBytes []string
-			for _, b := range payload {
-				hexBytes = append(hexBytes, fmt.Sprintf("%X", b))
-			}
+		for _, cell := range manufacturerCells(dev.ManufacturerData(), &companyNames) {
 			w.table.AppendRow(table.Row{
 				dev.scanResult.Address.String(),
-				getCompanyName(&companyNames, dev.CompanyID()),
-				fmt.Sprintf("%v: %v", hexBytes, len(hexBytes)),
+				cell.company,
+				cell.data,
 				isAirTag,
 				isAirPods,
 				ownerNearby,

--- a/devicewriter_test.go
+++ b/devicewriter_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// A device broadcasting more than one manufacturer-data entry must have each row
+// labeled with THAT entry's company, not the device-wide (Apple-preferred)
+// CompanyID. This is the regression guard for the mislabeled-company bug.
+func TestManufacturerCells_LabelsEachEntryWithItsOwnCompany(t *testing.T) {
+	names := CompanyIdentifiers{
+		appleCompanyID: "Apple, Inc.",
+		0x0006:         "Microsoft",
+	}
+	md := map[uint16][]byte{
+		appleCompanyID: {0x12, 0x19},
+		0x0006:         {0x01, 0x02, 0x03},
+	}
+
+	got := manufacturerCells(md, &names)
+	if len(got) != 2 {
+		t.Fatalf("manufacturerCells returned %d cells, want 2", len(got))
+	}
+
+	// Find each entry by its data payload and check the paired company.
+	byData := map[string]string{}
+	for _, c := range got {
+		byData[c.data] = c.company
+	}
+	if company := byData["[12 19]: 2"]; company != "Apple, Inc." {
+		t.Errorf("Apple payload paired with %q, want %q", company, "Apple, Inc.")
+	}
+	if company := byData["[1 2 3]: 3"]; company != "Microsoft" {
+		t.Errorf("Microsoft payload paired with %q, want %q", company, "Microsoft")
+	}
+}
+
+// An empty payload must still produce a full data cell so the caller emits a
+// full-width row, not a single-column "None" row that misaligns under the header.
+func TestManufacturerCells_EmptyPayloadIsFullCell(t *testing.T) {
+	names := CompanyIdentifiers{0x0006: "Microsoft"}
+	md := map[uint16][]byte{0x0006: {}}
+
+	got := manufacturerCells(md, &names)
+	if len(got) != 1 {
+		t.Fatalf("manufacturerCells returned %d cells, want 1", len(got))
+	}
+	if got[0].data != "(none)" {
+		t.Errorf("empty payload data cell = %q, want %q", got[0].data, "(none)")
+	}
+	if got[0].company != "Microsoft" {
+		t.Errorf("empty payload company = %q, want %q", got[0].company, "Microsoft")
+	}
+}
+
+// Unknown company IDs fall through to the getCompanyName default rather than
+// dropping the entry.
+func TestManufacturerCells_UnknownCompany(t *testing.T) {
+	names := CompanyIdentifiers{}
+	md := map[uint16][]byte{0x9999: {0xAB}}
+
+	got := manufacturerCells(md, &names)
+	if len(got) != 1 {
+		t.Fatalf("manufacturerCells returned %d cells, want 1", len(got))
+	}
+	if got[0].company != "Unknown" {
+		t.Errorf("unknown company = %q, want %q", got[0].company, "Unknown")
+	}
+	if !strings.Contains(got[0].data, "AB") {
+		t.Errorf("data cell %q missing hex payload", got[0].data)
+	}
+}
+
+// Guard the invariant directly: every entry's rendered hex must belong to the
+// company it is paired with, across many randomized map-iteration orders.
+func TestManufacturerCells_NoCrossPairing(t *testing.T) {
+	names := CompanyIdentifiers{appleCompanyID: "Apple, Inc.", 0x0006: "Microsoft"}
+	want := map[string]string{"Apple, Inc.": "[12]: 1", "Microsoft": "[34]: 1"}
+	md := map[uint16][]byte{appleCompanyID: {0x12}, 0x0006: {0x34}}
+
+	for i := 0; i < 50; i++ {
+		got := manufacturerCells(md, &names)
+		pairs := make([]string, 0, len(got))
+		for _, c := range got {
+			if want[c.company] != c.data {
+				t.Fatalf("company %q paired with %q, want %q", c.company, c.data, want[c.company])
+			}
+			pairs = append(pairs, c.company)
+		}
+		sort.Strings(pairs)
+		if strings.Join(pairs, ",") != "Apple, Inc.,Microsoft" {
+			t.Fatalf("missing a company in output: %v", pairs)
+		}
+	}
+}


### PR DESCRIPTION
## What
Fixes two bugs in the device-table render loop (`devicewriter.go`) that fire whenever a device broadcasts manufacturer data.

**Bug 1 — mislabeled company (beads-jcn).** The loop ranged `dev.ManufacturerData()` (a `map[uint16][]byte`) discarding the company-ID key, then labeled *every* row with the device-wide `dev.CompanyID()`, which is Apple-preferred. A device broadcasting a non-Apple entry alongside an Apple one had its non-Apple hex payload printed under an "Apple" label.

**Bug 2 — misaligned empty-payload row (beads-e6p).** An empty payload appended `table.Row{"None"}` — a single column under a 10-column header, so the row misaligned.

## How
Extracted the per-entry pairing into a pure `manufacturerCells()` helper: each cell takes its company name from *that entry's* map key (`getCompanyName(names, companyID)`), and an empty payload renders as `"(none)"` so the caller always emits a full-width row. `render()` now iterates the returned cells.

## Tests
Added `devicewriter_test.go` with four focused tests: per-entry labeling, empty-payload full cell, unknown-company fallthrough, and a 50-iteration no-cross-pairing invariant (guards against the randomized map-iteration order re-introducing a mispair). `go build`, `go vet`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)